### PR TITLE
Enhancement for ModelValidationType.EXCLUSION and ModelValidationType.INCLUSION

### DIFF
--- a/src/main/java/ch/rasc/extclassgenerator/validation/AbstractValidation.java
+++ b/src/main/java/ch/rasc/extclassgenerator/validation/AbstractValidation.java
@@ -17,7 +17,9 @@ package ch.rasc.extclassgenerator.validation;
 
 import java.lang.annotation.Annotation;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.core.annotation.AnnotationUtils;
@@ -144,11 +146,21 @@ public abstract class AbstractValidation {
 			case FUTURE:
 				return new FutureValidation(propertyName);
 			case INCLUSION:
-				String list = getParameterValue(modelValidationAnnotation.parameters(), "list");
-				return new InclusionValidation(propertyName, list);
+				if (modelValidationAnnotation.exclusionOrInclusionList().length > 0) {
+					List<String> list = Arrays.asList(modelValidationAnnotation.exclusionOrInclusionList());
+					return new InclusionValidationArray(propertyName, list);
+				} else {// backward compatibility
+					String list = getParameterValue(modelValidationAnnotation.parameters(), "list");
+					return new InclusionValidation(propertyName, list);
+				}
 			case EXCLUSION:
-				list = getParameterValue(modelValidationAnnotation.parameters(), "list");
-				return new ExclusionValidation(propertyName, list);
+				if (modelValidationAnnotation.exclusionOrInclusionList().length > 0) {
+					List<String> list = Arrays.asList(modelValidationAnnotation.exclusionOrInclusionList());
+					return new ExclusionValidationArray(propertyName, list);
+				} else {// backward compatibility
+					String list = getParameterValue(modelValidationAnnotation.parameters(), "list");
+					return new ExclusionValidation(propertyName, list);
+				}
 			case LENGTH:
 				String minValue = getParameterValue(modelValidationAnnotation.parameters(), "min");
 				String maxValue = getParameterValue(modelValidationAnnotation.parameters(), "max");

--- a/src/main/java/ch/rasc/extclassgenerator/validation/ExclusionValidationArray.java
+++ b/src/main/java/ch/rasc/extclassgenerator/validation/ExclusionValidationArray.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2013-2014 Ralph Schaer <ralphschaer@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.rasc.extclassgenerator.validation;
+
+import java.util.List;
+
+public class ExclusionValidationArray extends AbstractValidation {
+
+	
+	private final List<String> list;
+
+	public ExclusionValidationArray(String field,  List<String> list) {
+		super("exclusion", field);
+
+		this.list = list;
+	}
+
+	public  List<String> getList() {
+		return list;
+	}
+
+}

--- a/src/main/java/ch/rasc/extclassgenerator/validation/InclusionValidationArray.java
+++ b/src/main/java/ch/rasc/extclassgenerator/validation/InclusionValidationArray.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2013-2014 Ralph Schaer <ralphschaer@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.rasc.extclassgenerator.validation;
+
+import java.util.List;
+
+
+public class InclusionValidationArray extends AbstractValidation {
+
+	private final List<String> list;
+
+	public InclusionValidationArray(String field, List<String> list) {
+		super("inclusion", field);
+
+		this.list = list;
+	}
+
+	public List<String> getList() {
+		return list;
+	}
+
+}

--- a/src/test/java/ch/rasc/extclassgenerator/ModelGeneratorBeanWithGenericValidationTest.java
+++ b/src/test/java/ch/rasc/extclassgenerator/ModelGeneratorBeanWithGenericValidationTest.java
@@ -25,7 +25,11 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import ch.rasc.extclassgenerator.bean.BeanWithGenericValidation;
+import ch.rasc.extclassgenerator.validation.ExclusionValidation;
+import ch.rasc.extclassgenerator.validation.ExclusionValidationArray;
 import ch.rasc.extclassgenerator.validation.GenericValidation;
+import ch.rasc.extclassgenerator.validation.InclusionValidation;
+import ch.rasc.extclassgenerator.validation.InclusionValidationArray;
 import ch.rasc.extclassgenerator.validation.LengthValidation;
 import ch.rasc.extclassgenerator.validation.PresenceValidation;
 import ch.rasc.extclassgenerator.validation.RangeValidation;
@@ -115,15 +119,15 @@ public class ModelGeneratorBeanWithGenericValidationTest {
 		assertThat(modelBean.getIdProperty()).isNull();
 		assertThat(modelBean.isPaging()).isFalse();
 		assertThat(modelBean.getName()).isEqualTo("ch.rasc.extclassgenerator.bean.BeanWithGenericValidation");
-		assertThat(modelBean.getFields()).hasSize(1);
-		assertThat(BeanWithGenericValidation.expectedFields).hasSize(1);
+		assertThat(modelBean.getFields()).hasSize(6);
+		assertThat(BeanWithGenericValidation.expectedFields).hasSize(6);
 
 		for (ModelFieldBean expectedField : BeanWithGenericValidation.expectedFields) {
 			ModelFieldBean field = modelBean.getFields().get(expectedField.getName());
 			assertThat(field).isEqualsToByComparingFields(expectedField);
 		}
 
-		assertThat(modelBean.getValidations()).hasSize(2);
+		assertThat(modelBean.getValidations()).hasSize(7);
 
 		assertThat(modelBean.getValidations().get(0)).isInstanceOf(PresenceValidation.class);
 		PresenceValidation presenceValidation = (PresenceValidation) modelBean.getValidations().get(0);
@@ -134,6 +138,32 @@ public class ModelGeneratorBeanWithGenericValidationTest {
 		assertThat(genericValidation.getType()).isEqualTo("notUnique");
 		assertThat(genericValidation.getField()).isEqualTo("singleton");
 
+		assertThat(modelBean.getValidations().get(1)).isInstanceOf(GenericValidation.class);
+		ExclusionValidationArray exclusionValidationArray = (ExclusionValidationArray) modelBean.getValidations()
+				.get(2);
+		assertThat(exclusionValidationArray.getType()).isEqualTo("exclusion");
+		assertThat(exclusionValidationArray.getField()).isEqualTo("excluded");
+
+		assertThat(modelBean.getValidations().get(1)).isInstanceOf(GenericValidation.class);
+		exclusionValidationArray = (ExclusionValidationArray) modelBean.getValidations().get(3);
+		assertThat(exclusionValidationArray.getType()).isEqualTo("exclusion");
+		assertThat(exclusionValidationArray.getField()).isEqualTo("excluded2");
+
+		assertThat(modelBean.getValidations().get(1)).isInstanceOf(GenericValidation.class);
+		InclusionValidationArray inclusionValidationArray = (InclusionValidationArray) modelBean.getValidations()
+				.get(4);
+		assertThat(inclusionValidationArray.getType()).isEqualTo("inclusion");
+		assertThat(inclusionValidationArray.getField()).isEqualTo("included");
+
+		assertThat(modelBean.getValidations().get(1)).isInstanceOf(GenericValidation.class);
+		ExclusionValidation exclusionValidation = (ExclusionValidation) modelBean.getValidations().get(5);
+		assertThat(exclusionValidation.getType()).isEqualTo("exclusion");
+		assertThat(exclusionValidation.getField()).isEqualTo("excludedV1");
+
+		assertThat(modelBean.getValidations().get(1)).isInstanceOf(GenericValidation.class);
+		InclusionValidation inclusionValidation = (InclusionValidation) modelBean.getValidations().get(6);
+		assertThat(inclusionValidation.getType()).isEqualTo("inclusion");
+		assertThat(inclusionValidation.getField()).isEqualTo("includedV1");
 	}
 
 	@Test

--- a/src/test/java/ch/rasc/extclassgenerator/bean/BeanWithGenericValidation.java
+++ b/src/test/java/ch/rasc/extclassgenerator/bean/BeanWithGenericValidation.java
@@ -28,16 +28,46 @@ import ch.rasc.extclassgenerator.ModelValidations;
 @ModelValidations({ @ModelValidation(propertyName = "singleton", value = ModelValidationType.PRESENCE) })
 public class BeanWithGenericValidation {
 
-
-	@ModelValidation(value = ModelValidationType.GENERIC, parameters={@ModelValidationParameter(name="type", value= "notUnique"), @ModelValidationParameter(name="update", value= "true")})
+	@ModelValidation(value = ModelValidationType.GENERIC, parameters = {
+			@ModelValidationParameter(name = "type", value = "notUnique"),
+			@ModelValidationParameter(name = "update", value = "true") })
 	public String singleton;
 
+	@ModelValidation(value = ModelValidationType.EXCLUSION, exclusionOrInclusionList = { "_" })
+	public String excluded;
+
+	@ModelValidation(value = ModelValidationType.EXCLUSION, exclusionOrInclusionList = { "_", "*" })
+	public String excluded2;
+
+	@ModelValidation(value = ModelValidationType.INCLUSION, exclusionOrInclusionList = { "fish", "fruit" })
+	public String included;
+
+	@ModelValidation(value = ModelValidationType.EXCLUSION, parameters = @ModelValidationParameter(name = "list", value = "[\"_\"]"))
+	public String excludedV1;
+
+	@ModelValidation(value = ModelValidationType.INCLUSION, parameters = @ModelValidationParameter(name = "list", value = "[\"fish\",\"fruit\"]"))
+	public String includedV1;
 
 	public static List<ModelFieldBean> expectedFields = new ArrayList<ModelFieldBean>();
 	static {
 
 		ModelFieldBean field = new ModelFieldBean("singleton", ModelType.STRING);
 		expectedFields.add(field);
-		
+
+		field = new ModelFieldBean("excluded", ModelType.STRING);
+		expectedFields.add(field);
+
+		field = new ModelFieldBean("excluded2", ModelType.STRING);
+		expectedFields.add(field);
+
+		field = new ModelFieldBean("included", ModelType.STRING);
+		expectedFields.add(field);
+
+		field = new ModelFieldBean("excludedV1", ModelType.STRING);
+		expectedFields.add(field);
+
+		field = new ModelFieldBean("includedV1", ModelType.STRING);
+		expectedFields.add(field);
+
 	}
 }

--- a/src/test/resources/generator/BeanWithGenericValidationExtJs4.json
+++ b/src/test/resources/generator/BeanWithGenericValidationExtJs4.json
@@ -4,6 +4,21 @@ Ext.define("ch.rasc.extclassgenerator.bean.BeanWithGenericValidation",
   fields : [ {
     name : "singleton",
     type : "string"
+  }, {
+    name : "excluded",
+    type : "string"
+  }, {
+    name : "excluded2",
+    type : "string"
+  }, {
+    name : "included",
+    type : "string"
+  }, {
+    name : "excludedV1",
+    type : "string"
+  }, {
+    name : "includedV1",
+    type : "string"
   } ],
   validations : [ {
     type : "presence",
@@ -12,5 +27,25 @@ Ext.define("ch.rasc.extclassgenerator.bean.BeanWithGenericValidation",
     type : "notUnique",
     field : "singleton",
     update : "true"
+  }, {
+    type : "exclusion",
+    field : "excluded",
+    list : [ "_" ]
+  }, {
+    type : "exclusion",
+    field : "excluded2",
+    list : [ "_", "*" ]
+  }, {
+    type : "inclusion",
+    field : "included",
+    list : [ "fish", "fruit" ]
+  }, {
+    type : "exclusion",
+    field : "excludedV1",
+    list : ["_"]
+  }, {
+    type : "inclusion",
+    field : "includedV1",
+    list : ["fish","fruit"]
   } ]
 });

--- a/src/test/resources/generator/BeanWithGenericValidationExtJs5.json
+++ b/src/test/resources/generator/BeanWithGenericValidationExtJs5.json
@@ -4,6 +4,21 @@ Ext.define("ch.rasc.extclassgenerator.bean.BeanWithGenericValidation",
   fields : [ {
     name : "singleton",
     type : "string"
+  }, {
+    name : "excluded",
+    type : "string"
+  }, {
+    name : "excluded2",
+    type : "string"
+  }, {
+    name : "included",
+    type : "string"
+  }, {
+    name : "excludedV1",
+    type : "string"
+  }, {
+    name : "includedV1",
+    type : "string"
   } ],
   validations : [ {
     type : "presence",
@@ -12,5 +27,25 @@ Ext.define("ch.rasc.extclassgenerator.bean.BeanWithGenericValidation",
     type : "notUnique",
     field : "singleton",
     update : "true"
+  }, {
+    type : "exclusion",
+    field : "excluded",
+    list : [ "_" ]
+  }, {
+    type : "exclusion",
+    field : "excluded2",
+    list : [ "_", "*" ]
+  }, {
+    type : "inclusion",
+    field : "included",
+    list : [ "fish", "fruit" ]
+  }, {
+    type : "exclusion",
+    field : "excludedV1",
+    list : ["_"]
+  }, {
+    type : "inclusion",
+    field : "includedV1",
+    list : ["fish","fruit"]
   } ]
 });

--- a/src/test/resources/generator/BeanWithGenericValidationTouch2.json
+++ b/src/test/resources/generator/BeanWithGenericValidationTouch2.json
@@ -5,6 +5,21 @@ Ext.define("ch.rasc.extclassgenerator.bean.BeanWithGenericValidation",
     fields : [ {
       name : "singleton",
       type : "string"
+    }, {
+      name : "excluded",
+      type : "string"
+    }, {
+      name : "excluded2",
+      type : "string"
+    }, {
+      name : "included",
+      type : "string"
+    }, {
+      name : "excludedV1",
+      type : "string"
+    }, {
+      name : "includedV1",
+      type : "string"
     } ],
     validations : [ {
       type : "presence",
@@ -13,6 +28,26 @@ Ext.define("ch.rasc.extclassgenerator.bean.BeanWithGenericValidation",
       type : "notUnique",
       field : "singleton",
       update : "true"
+    }, {
+      type : "exclusion",
+      field : "excluded",
+      list : [ "_" ]
+    }, {
+      type : "exclusion",
+      field : "excluded2",
+      list : [ "_", "*" ]
+    }, {
+      type : "inclusion",
+      field : "included",
+      list : [ "fish", "fruit" ]
+    }, {
+      type : "exclusion",
+      field : "excludedV1",
+      list : ["_"]
+    }, {
+      type : "inclusion",
+      field : "includedV1",
+      list : ["fish","fruit"]
     } ]
   }
 });


### PR DESCRIPTION
for ModelValidationType.EXCLUSION and ModelValidationType.INCLUSION, add
a specific field to ease the generation of exclusion and inclusion list.
It is backward compatible.

from request https://github.com/ralscha/extclassgenerator-annotations/issues/2.
Implementation differs from request to avoid breaking existing implementation

Unit Tests were added
