### PR TITLE
Let name pass through in hasOne.

### DIFF
--- a/src/main/java/ch/rasc/extclassgenerator/association/AbstractAssociation.java
+++ b/src/main/java/ch/rasc/extclassgenerator/association/AbstractAssociation.java
@@ -260,8 +260,7 @@ public abstract class AbstractAssociation {
 						getWarningText(null, name, association.getType(), "autoLoad"));
 			}
 			if (StringUtils.hasText(associationAnnotation.name())) {
-				LogFactory.getLog(ModelGenerator.class)
-						.warn(getWarningText(null, name, association.getType(), "name"));
+				hasOneAssociation.setName(associationAnnotation.name());
 			}
 		}
 
@@ -410,9 +409,9 @@ public abstract class AbstractAssociation {
 				LogFactory.getLog(ModelGenerator.class).warn(getWarningText(
 						declaringClass, name, association.getType(), "autoLoad"));
 			}
+
 			if (StringUtils.hasText(associationAnnotation.name())) {
-				LogFactory.getLog(ModelGenerator.class).warn(getWarningText(
-						declaringClass, name, association.getType(), "name"));
+				hasOneAssociation.setName(associationAnnotation.name());
 			}
 		}
 

--- a/src/main/java/ch/rasc/extclassgenerator/association/HasOneAssociation.java
+++ b/src/main/java/ch/rasc/extclassgenerator/association/HasOneAssociation.java
@@ -30,6 +30,8 @@ public class HasOneAssociation extends AbstractAssociation {
 
 	private String getterName;
 
+	private String name;
+
 	/**
 	 * Creates an instance of a hasOne association. Sets {@link #model} to the provided
 	 * parameters.
@@ -87,4 +89,11 @@ public class HasOneAssociation extends AbstractAssociation {
 		this.getterName = getterName;
 	}
 
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
 }

--- a/src/test/resources/generator/AddressExtJs4.json
+++ b/src/test/resources/generator/AddressExtJs4.json
@@ -16,6 +16,7 @@ Ext.define("ch.rasc.extclassgenerator.bean.Address",
     foreignKey : "e_id",
     primaryKey : "eId",
     setterName : "setE",
-    getterName : "getE"
+    getterName : "getE",
+    name : "emp"
   } ]
 });

--- a/src/test/resources/generator/AddressExtJs5.json
+++ b/src/test/resources/generator/AddressExtJs5.json
@@ -16,6 +16,7 @@ Ext.define("ch.rasc.extclassgenerator.bean.Address",
     foreignKey : "e_id",
     primaryKey : "eId",
     setterName : "setE",
-    getterName : "getE"
+    getterName : "getE",
+    name : "emp"
   } ]
 });

--- a/src/test/resources/generator/AddressTouch2.json
+++ b/src/test/resources/generator/AddressTouch2.json
@@ -17,7 +17,8 @@ Ext.define("ch.rasc.extclassgenerator.bean.Address",
       foreignKey : "e_id",
       primaryKey : "eId",
       setterName : "setE",
-      getterName : "getE"
+      getterName : "getE",
+      name : "emp"
     } ]
   }
 });


### PR DESCRIPTION
Without name, in Ext 6 (at least) you can't have two
hasOne associations to the same entity type.

For example:

    @Getter
    @ModelAssociation(value = ModelAssociationType.HAS_ONE, name = "UserEditModelToModifiedBy")
    private UserListModel modifiedBy;

    @Getter
    @ModelAssociation(value = ModelAssociationType.HAS_ONE, name = "UserEditModelToCreatedBy")
    private UserListModel createdBy;

In Ext 6 (and 5) hasOne is deprecated anyway.  At some point, should probably consider
adding support for schemas and defining associations in the new way:

https://docs.sencha.com/extjs/6.0/6.0.1-classic/#!/api/Ext.data.schema.Association

I doubt this is breaking change for older versions, but, I have not tested against them.